### PR TITLE
Fix breaking change to URI parsing

### DIFF
--- a/main.dart
+++ b/main.dart
@@ -33,7 +33,7 @@ Future<PodCastIndex> fetchPodCastIndex() async {
   };
 
   final response = await http.get(
-      'https://api.podcastindex.org/api/1.0/search/byterm?q=bastiat',
+      Uri.parse('https://api.podcastindex.org/api/1.0/search/byterm?q=bastiat'),
       headers: headers);
 
   if (response.statusCode == 200) {


### PR DESCRIPTION
Uri.Parse is now required in http.get when using a string. 

see https://stackoverflow.com/questions/66473263/the-argument-type-string-cant-be-assigned-to-the-parameter-type-uri and https://pub.dev/packages/http/changelog 0.13.0